### PR TITLE
Test AzdContext itself

### DIFF
--- a/DotAzure.Example/Program.cs
+++ b/DotAzure.Example/Program.cs
@@ -15,7 +15,7 @@ if (Loader.Load())
 
 var endpoint = new Uri(Environment.GetEnvironmentVariable(EnvironmentVariableName) ??
     throw new Exception($"{EnvironmentVariableName} not set"), UriKind.Absolute);
-var credential = new DefaultAzureCredential();
+var credential = new AzureDeveloperCliCredential();
 var client = new SecretClient(endpoint, credential);
 
 KeyVaultSecret secret = await client.GetSecretAsync("my-secret");

--- a/DotAzure.Test/AzdContextTests.cs
+++ b/DotAzure.Test/AzdContextTests.cs
@@ -122,7 +122,7 @@ public sealed class AzdContextBuildsTests
         Assert.AreEqual("~/src/azure.yaml", sut.ProjectPath.NormalizePath());
         Assert.AreEqual("~/src/.azure", sut.EnvironmentDirectory.NormalizePath());
         Assert.AreEqual("test", sut.EnvironmentName);
-        Assert.AreEqual("~/src/.azure/test", sut.EnvironmentRoot);
-        Assert.AreEqual("~/src/.azure/test/.env", sut.EnvironmentFile);
+        Assert.AreEqual("~/src/.azure/test", sut.EnvironmentRoot.NormalizePath());
+        Assert.AreEqual("~/src/.azure/test/.env", sut.EnvironmentFile.NormalizePath());
     }
 }

--- a/DotAzure.Test/Helpers.cs
+++ b/DotAzure.Test/Helpers.cs
@@ -12,6 +12,7 @@ namespace DotAzure;
 internal static class Helpers
 {
     public static Stream ToStream(this ReadOnlySpan<byte> buffer) => new MemoryStream(buffer.ToArray());
+    public static string NormalizePath(this string path) => path.Replace(@"\", "/");
 }
 
 internal class PathComparer : IEqualityComparer<string>
@@ -24,5 +25,5 @@ internal class PathComparer : IEqualityComparer<string>
     public int GetHashCode(string obj) =>
         Replace(obj)!.GetHashCode();
 
-    private static string? Replace(string? s) => s?.Replace(@"\", "/");
+    private static string? Replace(string? s) => s?.NormalizePath();
 }


### PR DESCRIPTION
Also uses AzureDeveloperCliCredential in README.md since this is all centered around azd anyway, which means they have to have authenticated already.